### PR TITLE
Fix development instructions in README

### DIFF
--- a/.env/pyvenv.cfg
+++ b/.env/pyvenv.cfg
@@ -1,5 +1,0 @@
-home = /opt/homebrew/opt/python@3.11/bin
-include-system-site-packages = false
-version = 3.11.2
-executable = /opt/homebrew/Cellar/python@3.11/3.11.2/Frameworks/Python.framework/Versions/3.11/bin/python3.11
-command = /opt/homebrew/opt/python@3.11/bin/python3.11 -m venv /Users/kev/work/crate-crypto/py_arkworks_bls12381/.env

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ __pycache__/
 # Distribution / packaging
 .Python
 .venv/
+.env/
 env/
 bin/
 build/

--- a/README.md
+++ b/README.md
@@ -125,32 +125,42 @@ assert scalar == deserialised_scalar
 
 ##  Development
 
-You will need maturin to build the project.
+First, activate the virtual environment:
+
+```
+python3 -m venv .env
+source .env/bin/activate
+```
+
+Then, install `maturin` which is needed to build the project:
 
 ```
 pip install maturin
 ```
 
-
-- First activate the virtual environment
-
-```
- source .env/bin/activate
-```
-
-- Next build the rust package and install it in your virtual environment
+Next, build the rust package and install it in your virtual environment:
 
 ```
 maturin develop
 ```
 
-- Now run a file in the examples folder
+Finally, run a file in the examples folder:
 
 ```
 python3 examples/point.py
 ```
 
-# Benchmarks
+## Benchmarks
+
+This is to be executed in the virtual environment above.
+
+First, install `py_ecc` which is used as a comparison:
+
+```
+pip install py_ecc
+```
+
+Then, run the benchmarks with this command:
 
 ```
 python3 -m examples.benches.bench


### PR DESCRIPTION
The instructions in this repo for setting up the development environment are slightly incorrect.

* Missing the `python3 -m venv .env` command.
* Maturin must be installed in the venv.
* Missing the `pip install py_ecc` command for benchmarks.

See [the instructions in PyO3](https://github.com/PyO3/pyo3/blob/5d47fc67efce4ff60235dd77639d097f83f3e66a/README.md?plain=1#L31-L38) for reference.

Also, these two things:

* Fixes minor sentence structure nits of mine.
* Removes the tracked `.env/pyvenv.cfg` file & adds `.env` to the git ignore file.