### PR TITLE
Change Scalar::new input from u128 to BigUint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ name = "py_arkworks_bls12381"
 crate-type = ["cdylib"]
 
 [dependencies]
-pyo3 = { version = "0.18.0", features = ["extension-module"] }
+pyo3 = { version = "0.22.2", features = ["extension-module", "num-bigint"] }
 ark-bls12-381 = "0.4.0"
 ark-serialize = "0.4.0"
 ark-ec = "0.4.0"
@@ -17,6 +17,7 @@ ark-ff = "0.4.0"
 rayon = "1.6.1"
 hex = "0.4.3"
 num-traits = "0.2.15"
+num-bigint = "0.4.6"
 
 [features]
 default = ["parallel", "asm"]

--- a/examples/scalar.py
+++ b/examples/scalar.py
@@ -11,12 +11,20 @@ assert max_value + Scalar(2) == Scalar(1)
 assert scalar == scalar
 assert Scalar(1234) != Scalar(4567)
 
-# Scalar Addition/subtraction/Negation -- We override the add/sub/neg operators
+# Scalar arithmetic -- We override the mul/div/add/sub/neg operators
 a = Scalar(3)
 b = Scalar(4)
 c = Scalar(5)
 assert a.square() + b.square() == c.square()
 assert a * a + b * b == c * c
+
+assert Scalar(12) / Scalar(3) == Scalar(4)
+
+try:
+    assert Scalar(12) / Scalar(0)
+    assert False
+except ZeroDivisionError:
+    pass
 
 neg_a = -a
 assert a + neg_a == Scalar(0)
@@ -26,3 +34,6 @@ assert (a + neg_a).is_zero()
 compressed_bytes = scalar.to_le_bytes()
 deserialised_scalar = Scalar.from_le_bytes(compressed_bytes)
 assert scalar == deserialised_scalar
+
+# Conversion to int
+assert int(Scalar(12345)) == 12345

--- a/examples/scalar.py
+++ b/examples/scalar.py
@@ -3,6 +3,10 @@ from py_arkworks_bls12381 import Scalar
 # Initialisation - The default initialiser for a scalar is an u128 integer
 scalar = Scalar(12345)
 
+# It should be possible to instantiate BLS_MODULUS - 1
+max_value = Scalar(52435875175126190479447740508185965837690552500527637822603658699938581184512)
+assert max_value + Scalar(2) == Scalar(1)
+
 # Equality -- We override eq and neq operators
 assert scalar == scalar
 assert Scalar(1234) != Scalar(4567)

--- a/examples/scalar.py
+++ b/examples/scalar.py
@@ -1,10 +1,12 @@
 from py_arkworks_bls12381 import Scalar
 
+BLS_MODULUS = 52435875175126190479447740508185965837690552500527637822603658699938581184513
+
 # Initialisation - The default initialiser for a scalar is an u128 integer
 scalar = Scalar(12345)
 
 # It should be possible to instantiate BLS_MODULUS - 1
-max_value = Scalar(52435875175126190479447740508185965837690552500527637822603658699938581184512)
+max_value = Scalar(BLS_MODULUS - 1)
 assert max_value + Scalar(2) == Scalar(1)
 
 # Equality -- We override eq and neq operators
@@ -25,6 +27,9 @@ try:
     assert False
 except ZeroDivisionError:
     pass
+
+exp = Scalar(0xffff_ffff_ffff_fff)
+assert int(Scalar(2).pow(exp)) == pow(2, int(exp), BLS_MODULUS)
 
 neg_a = -a
 assert a + neg_a == Scalar(0)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,7 @@ use wrapper::{G1Point, G2Point, Scalar, GT};
 
 /// A Python module implemented in Rust.
 #[pymodule]
-fn py_arkworks_bls12381(_py: Python, m: &PyModule) -> PyResult<()> {
+fn py_arkworks_bls12381(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<G1Point>()?;
     m.add_class::<G2Point>()?;
     m.add_class::<GT>()?;

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -2,7 +2,7 @@ use std::str::FromStr;
 use ark_bls12_381::{G1Affine, G1Projective, G2Affine, G2Projective};
 use ark_ec::pairing::{Pairing, PairingOutput};
 use ark_ec::{AffineRepr, Group, ScalarMul, VariableBaseMSM};
-use ark_ff::{One, PrimeField};
+use ark_ff::One;
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize, SerializationError};
 use num_traits::identities::Zero;
 use pyo3::{exceptions, pyclass, pymethods, PyErr, PyResult, Python};
@@ -12,6 +12,7 @@ use num_bigint::BigUint;
 const G1_COMPRESSED_SIZE: usize = 48;
 const G2_COMPRESSED_SIZE: usize = 96;
 const SCALAR_SIZE: usize = 32;
+const BLS_MODULUS: &str = "52435875175126190479447740508185965837690552500527637822603658699938581184513";
 
 #[derive(Copy, Clone)]
 #[pyclass]
@@ -226,14 +227,16 @@ impl Scalar {
         BigUint::from_str(&*self.0.to_string()).unwrap_or(BigUint::ZERO)
     }
 
-    fn pow(&self, exp: Scalar) -> Scalar {
-        // TODO: This is ugly, clean up.
-        let base_bigint = BigUint::from_bytes_le(self.to_le_bytes().unwrap().as_slice());
-        let exp_bigint = BigUint::from_bytes_le(exp.to_le_bytes().unwrap().as_slice());
-        let bls_modulus = BigUint::from_str("52435875175126190479447740508185965837690552500527637822603658699938581184513").unwrap();
+    fn pow(&self, exp: Scalar) -> PyResult<Scalar> {
+        let bls_modulus = BigUint::from_str(BLS_MODULUS).unwrap();
+        let base_bigint = BigUint::from_bytes_le(self.to_le_bytes()?.as_slice());
+        let exp_bigint = BigUint::from_bytes_le(exp.to_le_bytes()?.as_slice());
         let result = base_bigint.modpow(&exp_bigint, &bls_modulus);
-        let fr = ark_bls12_381::Fr::from_str(&*result.to_string()).unwrap();
-        Scalar(fr)
+        Ok(Scalar(
+            ark_bls12_381::Fr::from_str(&*result.to_string()).map_err(|_| {
+                exceptions::PyValueError::new_err("Failed to convert result to scalar")
+            })?,
+        ))
     }
     fn square(&self) -> Scalar {
         use ark_ff::fields::Field;


### PR DESCRIPTION
This PR does these things:

* Update `pyo3` to the latest version.
* Add the `num-bigint` feature which allows us to use bigints.
* Update the `Scalar::new` method to take `BigUint` instead of `u128`.
* Add a quick test to `examples/scalar.py` to ensure it works.
* Override `__truediv__` to allow scalar division.
* Override `__int__` so we can convert back to an integer in Python.