### PR TITLE
Refactor Scalar::pow method to not use BigUints

### DIFF
--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -2,7 +2,7 @@ use std::str::FromStr;
 use ark_bls12_381::{G1Affine, G1Projective, G2Affine, G2Projective};
 use ark_ec::pairing::{Pairing, PairingOutput};
 use ark_ec::{AffineRepr, Group, ScalarMul, VariableBaseMSM};
-use ark_ff::One;
+use ark_ff::{Field, One, PrimeField};
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize, SerializationError};
 use num_traits::identities::Zero;
 use pyo3::{exceptions, pyclass, pymethods, PyErr, PyResult, Python};
@@ -12,7 +12,6 @@ use num_bigint::BigUint;
 const G1_COMPRESSED_SIZE: usize = 48;
 const G2_COMPRESSED_SIZE: usize = 96;
 const SCALAR_SIZE: usize = 32;
-const BLS_MODULUS: &str = "52435875175126190479447740508185965837690552500527637822603658699938581184513";
 
 #[derive(Copy, Clone)]
 #[pyclass]
@@ -227,16 +226,8 @@ impl Scalar {
         BigUint::from_str(&*self.0.to_string()).unwrap_or(BigUint::ZERO)
     }
 
-    fn pow(&self, exp: Scalar) -> PyResult<Scalar> {
-        let bls_modulus = BigUint::from_str(BLS_MODULUS).unwrap();
-        let base_bigint = BigUint::from_bytes_le(self.to_le_bytes()?.as_slice());
-        let exp_bigint = BigUint::from_bytes_le(exp.to_le_bytes()?.as_slice());
-        let result = base_bigint.modpow(&exp_bigint, &bls_modulus);
-        Ok(Scalar(
-            ark_bls12_381::Fr::from_str(&*result.to_string()).map_err(|_| {
-                exceptions::PyValueError::new_err("Failed to convert result to scalar")
-            })?,
-        ))
+    fn pow(&self, exp: Scalar) -> Scalar {
+        Scalar(self.0.pow(exp.0.into_bigint()))
     }
     fn square(&self) -> Scalar {
         use ark_ff::fields::Field;


### PR DESCRIPTION
Kev pointed out that we can use Arkwork's pow method for this. It took me a little while to figure out how to use this.

Got the idea from Arkworks' code here:

https://github.com/arkworks-rs/algebra/blob/b33df5cce2d54cf4c9248e4b229c7d6708fa9375/ec/src/pairing.rs#L330