### PR TITLE
Remove to_string from Scalar::__int__ method

### DIFF
--- a/examples/scalar.py
+++ b/examples/scalar.py
@@ -41,4 +41,5 @@ deserialised_scalar = Scalar.from_le_bytes(compressed_bytes)
 assert scalar == deserialised_scalar
 
 # Conversion to int
+assert int(Scalar(0)) == 0
 assert int(Scalar(12345)) == 12345

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -1,7 +1,7 @@
 use ark_bls12_381::{G1Affine, G1Projective, G2Affine, G2Projective};
 use ark_ec::pairing::{Pairing, PairingOutput};
 use ark_ec::{AffineRepr, Group, ScalarMul, VariableBaseMSM};
-use ark_ff::One;
+use ark_ff::{One, PrimeField};
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize, SerializationError};
 use num_bigint::BigUint;
 use num_traits::identities::Zero;
@@ -231,8 +231,7 @@ impl Scalar {
         }
     }
     fn __int__(&self) -> BigUint {
-        // Bug, Fr::to_string will print nothing if the value is zero
-        BigUint::from_str(&*self.0.to_string()).unwrap_or(BigUint::ZERO)
+        BigUint::from(self.0.into_bigint())
     }
 
     fn pow(&self, exp: Scalar) -> PyResult<Scalar> {

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -1,7 +1,7 @@
 use ark_bls12_381::{G1Affine, G1Projective, G2Affine, G2Projective};
 use ark_ec::pairing::{Pairing, PairingOutput};
 use ark_ec::{AffineRepr, Group, ScalarMul, VariableBaseMSM};
-use ark_ff::{One, PrimeField};
+use ark_ff::{Field, One, PrimeField};
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize, SerializationError};
 use num_bigint::BigUint;
 use num_traits::identities::Zero;


### PR DESCRIPTION
Using `from` & `into_bigint` is much cleaner, safer, and probably faster!